### PR TITLE
xor.py: fix for loop's off by one error

### DIFF
--- a/xor.py
+++ b/xor.py
@@ -3,7 +3,7 @@ import sys
 
 def xorcrypt(data, key):
     result = ''
-    pad = key*(len(data)/len(key)) + key[:(len(data)%len(key))-1]
+    pad = key*(len(data)/len(key)) + key[:(len(data)%len(key))]
     for i in range(len(data)-1):
         result += chr (ord(data[i]) ^ ord(pad[i]))        
     return result


### PR DESCRIPTION
if the message happens to be padded by a newline or space it would be "fine"